### PR TITLE
[BUGFIX] getText file: update available properties

### DIFF
--- a/Documentation/DataTypes/Gettext/Index.rst
+++ b/Documentation/DataTypes/Gettext/Index.rst
@@ -412,7 +412,7 @@ current file with "current" as UID like "file : current : size".
 
 The following properties are available:
 
-name, size, sha1, extension, mime_type, contents, publicUrl, localPath, modification_date, creation_date
+name, uid, originalUid, size, sha1, extension, mimetype, contents, publicUrl, modification_date, creation_date
 
 Furthermore when manipulating references (such as images in content
 elements or media in pages), additional properties are available (not
@@ -545,4 +545,3 @@ global:
 
 global: [GLOBAL variable, split with \| if you want to get from an
 array! Deprecated, use GP, TSFE or getenv!]
-


### PR DESCRIPTION
Add missing properties uid, originalUid. Remove typo in mimetype.
Remove localPath property which was removed to avoid stale files
(#65727).
