### PR TITLE
[BUGFIX] getText file: removed property localPath

### DIFF
--- a/Documentation/DataTypes/Gettext/Index.rst
+++ b/Documentation/DataTypes/Gettext/Index.rst
@@ -406,7 +406,7 @@ current file with "current" as UID like "file : current : size".
 
 The following properties are available:
 
-name, size, sha1, extension, mime_type, contents, publicUrl, localPath, modification_date, creation_date
+name, size, sha1, extension, mime_type, contents, publicUrl, modification_date, creation_date
 
 Furthermore when manipulating references (such as images in content
 elements or media in pages), additional properties are available (not


### PR DESCRIPTION
Remove localPath property which was removed to avoid
stale files (#65727).
